### PR TITLE
Simplify auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ Once the container is up and running, you can add the server as a Live TV and DV
 
 In Plex, go to Settings > Live TV & DVR > Set Up Plex DVR.
 
-If the server is not found automatically, click "Don't see your HDHomeRun device? Enter its network address manually" and enter the address and port that the server is running on, like `http://192.168.1.2:22708`.
+If the server is not found automatically, click "Don't see your HDHomeRun device? Enter its network address manually" and enter the address and port that the server is running on, like `http://192.168.1.2:22708`. Click Connect. You should see that it has discovered a number of channels equaling the number of Twitch channels that are followed by the configured user.
 
-Once the device is found, click Next. It should detect a channel for each of your followed channels on Twitch. If not, click Scan Channels. Click Continue.
-
-Next it will prompt for a ZIP code to download an electronic guide. In this case, the guide is served by twitch2tuner, so click "Have an XMLTV guide on your server? Click here to use that instead." Then enter the address of the server, followed by `/epg.xml`, like `http://192.168.1.2:22708/epg.xml`. Click Continue.
+Before allowing you to continue, Plex wants to discover the guide. There is a prompt to enter a ZIP code, but the Twitch guide is served by twitch2tuner, so click "Have an XMLTV guide on your server? Click here to use that instead." Then enter the address of the server, followed by `/epg.xml`, like `http://192.168.1.2:22708/epg.xml`. You may enter anything for the Guide Title. Click Continue.
 
 Plex should load the Electronic Program Guide and match the listings to the channel lineup from the tuner. Click Continue.
 

--- a/docker-template/twitch2tuner.xml
+++ b/docker-template/twitch2tuner.xml
@@ -18,7 +18,7 @@
     <Mode>bridge</Mode>
   </Networking>
   <Config Name="Client ID" Target="CLIENT_ID" Default="" Mode="" Description="The ID of the client to access the Twitch API" Type="Variable" Display="always" Required="true" Mask="false"></Config>
-  <Config Name="Access Token" Target="ACCESS_TOKEN" Default="" Mode="" Description="The access token to access the Twitch API" Type="Variable" Display="always" Required="true" Mask="false"></Config>
+  <Config Name="Client Secret" Target="CLIENT_SECRET" Default="" Mode="" Description="The secret of the client to access the Twitch API" Type="Variable" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Username" Target="TWITCH_USERNAME" Default="" Mode="" Description="The username of the user whose followed channels should be loaded" Type="Variable" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Stream Utility" Target="STREAM_UTILITY" Default="STREAMLINK" Mode="" Description="The name of the utility for extracting stream URLs (either YOUTUBE_DL or STREAMLINK)." Type="Variable" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Port" Target="22708" Default="22708" Mode="tcp" Description="Container Port: 22708" Type="Port" Display="always" Required="true" Mask="false">22708</Config>

--- a/docker-template/twitch2tuner.xml
+++ b/docker-template/twitch2tuner.xml
@@ -21,5 +21,5 @@
   <Config Name="Client Secret" Target="CLIENT_SECRET" Default="" Mode="" Description="The secret of the client to access the Twitch API" Type="Variable" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Username" Target="TWITCH_USERNAME" Default="" Mode="" Description="The username of the user whose followed channels should be loaded" Type="Variable" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Stream Utility" Target="STREAM_UTILITY" Default="STREAMLINK" Mode="" Description="The name of the utility for extracting stream URLs (either YOUTUBE_DL or STREAMLINK)." Type="Variable" Display="always" Required="true" Mask="false"></Config>
-  <Config Name="Port" Target="22708" Default="22708" Mode="tcp" Description="Container Port: 22708" Type="Port" Display="always" Required="true" Mask="false">22708</Config>
+  <Config Name="Port" Target="22708" Default="22708" Mode="tcp" Description="The external port to reach this service. Maps to container port 22708." Type="Port" Display="always" Required="true" Mask="false">22708</Config>
 </Container>

--- a/twitch2tuner.sln
+++ b/twitch2tuner.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B1BED75E-6A1F-4221-AE07-93030139542E}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
+		.gitignore = .gitignore
 		Dockerfile = Dockerfile
 		README.md = README.md
 		docker-template\twitch2tuner.xml = docker-template\twitch2tuner.xml

--- a/twitch2tuner/Config.cs
+++ b/twitch2tuner/Config.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using Swan.Logging;
 
 namespace twitch2tuner
 {
@@ -23,5 +25,44 @@ namespace twitch2tuner
             "STREAMLINK" => Streamlink.Instance,
             _ => Streamlink.Instance,
         };
+
+        /// <summary>
+        /// Verifies that all required configuration values are available
+        /// </summary>
+        /// <param name="exitOnError">Whether this method should exiting the running process when there is an error</param>
+        public static bool Verify(bool exitOnError = true)
+        {
+            bool result = true;
+
+            // First, verify that we have everything we need.
+            if (string.IsNullOrWhiteSpace(ClientId))
+            {
+                "Unable to load CLIENT_ID environment variable".Log(nameof(Program), LogLevel.Fatal);
+                result = false;
+            }
+
+            if (string.IsNullOrWhiteSpace(AccessToken))
+            {
+                "Unable to load ACCESS_TOKEN environment variable".Log(nameof(Program), LogLevel.Fatal);
+                result = false;
+            }
+
+            if (string.IsNullOrWhiteSpace(TwitchUsername))
+            {
+                "Unable to load TWITCH_USERNAME environment variable".Log(nameof(Program), LogLevel.Fatal);
+                result = false;
+            }
+
+            if (exitOnError && !result)
+            {
+                // This is a hack to wait for logging to be flushed since it is totally asynchronous.
+                // See https://github.com/unosquare/swan/issues/221
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                
+                Environment.Exit(1);
+            }
+
+            return result;
+        }
     }
 }

--- a/twitch2tuner/Config.cs
+++ b/twitch2tuner/Config.cs
@@ -15,7 +15,7 @@ namespace twitch2tuner
 
         public static string ClientId => Environment.GetEnvironmentVariable("CLIENT_ID");
 
-        public static string AccessToken => Environment.GetEnvironmentVariable("ACCESS_TOKEN");
+        public static string ClientSecret => Environment.GetEnvironmentVariable("CLIENT_SECRET");
 
         public static string TwitchUsername => Environment.GetEnvironmentVariable("TWITCH_USERNAME");
 
@@ -41,9 +41,9 @@ namespace twitch2tuner
                 result = false;
             }
 
-            if (string.IsNullOrWhiteSpace(AccessToken))
+            if (string.IsNullOrWhiteSpace(ClientSecret))
             {
-                "Unable to load ACCESS_TOKEN environment variable".Log(nameof(Program), LogLevel.Fatal);
+                "Unable to load CLIENT_SECRET environment variable".Log(nameof(Program), LogLevel.Fatal);
                 result = false;
             }
 

--- a/twitch2tuner/Program.cs
+++ b/twitch2tuner/Program.cs
@@ -11,6 +11,10 @@ namespace twitch2tuner
     {
         static async Task Main()
         {
+            // Verify the configuration.
+            // This will kill the app if anything is wrong.
+            Config.Verify();
+
             // Use pip (see Dockerfile) to install the latest version of youtube-dl and streamlink every time we start.
             // This command should download on first start, and upgrade on subsequent starts of the image.
             var pipProcess = Process.Start(new ProcessStartInfo

--- a/twitch2tuner/TwitchApiManager.cs
+++ b/twitch2tuner/TwitchApiManager.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Swan.Logging;
+using TwitchLib.Api;
+using TwitchLib.Api.Core;
+
+namespace twitch2tuner
+{
+    public static class TwitchApiManager
+    {
+        private static readonly TwitchAPI TwitchApi = new TwitchAPI(settings: new ApiSettings
+        {
+            ClientId = Config.ClientId,
+            AccessToken = Config.AccessToken
+        });
+
+        /// <summary>
+        /// Invoke the Twitch API
+        /// </summary>
+        public static Task<T> UseTwitchApi<T>(Func<TwitchAPI, Task<T>> action)
+        {
+            try
+            {
+                return action(TwitchApi);
+            }
+            catch (Exception ex)
+            {
+                $"Encountered an error invoking the Twitch API: {ex}".Log(nameof(TwitchApiManager), LogLevel.Error);
+                return Task.FromResult(default(T));
+            }
+        }
+    }
+}

--- a/twitch2tuner/TwitchApiManager.cs
+++ b/twitch2tuner/TwitchApiManager.cs
@@ -1,8 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Swan.Logging;
 using TwitchLib.Api;
 using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Exceptions;
+using TwitchLib.Api.Helix.Models.Users.GetUsers;
 
 namespace twitch2tuner
 {
@@ -10,15 +17,25 @@ namespace twitch2tuner
     {
         private static readonly TwitchAPI TwitchApi = new TwitchAPI(settings: new ApiSettings
         {
-            ClientId = Config.ClientId,
-            AccessToken = Config.AccessToken
+            ClientId = Config.ClientId
         });
 
         /// <summary>
         /// Invoke the Twitch API
         /// </summary>
-        public static async Task<T> UseTwitchApi<T>(Func<TwitchAPI, Task<T>> action)
+        /// <param name="action">The action to invoke on the current instance of the Twitch API client</param>
+        /// <param name="tryRefreshToken">
+        /// Whether or not this method is allowed to attempt to get a new access token if the current one is empty or expired.
+        /// Set this to false when invoking this method recursively.
+        /// </param>
+        public static async Task<T> UseTwitchApi<T>(Func<TwitchAPI, Task<T>> action, bool tryRefreshToken = true)
         {
+            if (string.IsNullOrEmpty(TwitchApi.Settings.AccessToken) && tryRefreshToken)
+            {
+                // First time, the access token will be null. Try to get it now.
+                await RetrieveAccessToken();
+            }
+
             try
             {
                 // Have to await here, instead of just returning the Task,
@@ -28,8 +45,57 @@ namespace twitch2tuner
             catch (Exception ex)
             {
                 $"Encountered an error invoking the Twitch API: {ex}".Log(nameof(TwitchApiManager), LogLevel.Error);
+
+                if ((ex is BadScopeException || ex is ClientIdAndOAuthTokenRequired) && tryRefreshToken)
+                {
+                    // These are the exceptions potentially caused by an expired access token. Try to get a new one.
+                    // If it works, try to invoke this method again on behalf of the caller before giving up.
+                    if (await RetrieveAccessToken())
+                    {
+                        return await UseTwitchApi(action, tryRefreshToken: false);
+                    }
+                }
+
                 return default;
             }
+        }
+
+        private static async Task<bool> RetrieveAccessToken()
+        {
+            "Attempting to retrieve new access token using client credentials flow.".Log(nameof(UseTwitchApi), LogLevel.Info);
+
+            HttpResponseMessage responseMessage = await new HttpClient().PostAsync(
+                "https://id.twitch.tv/oauth2/token?" +
+                $"client_id={Config.ClientId}&" +
+                $"client_secret={Config.ClientSecret}&" +
+                "grant_type=client_credentials&" +
+                "scope=user:read:subscriptions", new HttpResponseMessage().Content);
+
+            JsonElement jsonResponse = await responseMessage.Content.ReadFromJsonAsync<JsonElement>();
+            jsonResponse.TryGetProperty("access_token", out var accessTokenJson);
+            string accessToken = accessTokenJson.ToString();
+
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                $"There was an error retrieving new access token via client credentials flow. {jsonResponse}".Log(nameof(UseTwitchApi), LogLevel.Error);
+                return false;
+            }
+
+            // Assign the token to the client
+            TwitchApi.Settings.AccessToken = accessToken;
+
+            // Do a simple call to see if the token is good
+            // Set tryRefreshToken to false so we don't accidentally come back here
+            User twitchUser = (await UseTwitchApi(twitchApi => twitchApi.Helix.Users.GetUsersAsync(logins: new List<string> {Config.TwitchUsername}), tryRefreshToken: false))?.Users.FirstOrDefault();
+
+            if (twitchUser is null)
+            {
+                $"Got new access token, but unable to retrieve user {Config.TwitchUsername}. New access token may be bad. {jsonResponse}".Log(nameof(RetrieveAccessToken), LogLevel.Error);
+                return false;
+            }
+
+            $"Successfully got new access token and was able to retrieve user {Config.TwitchUsername}.".Log(nameof(RetrieveAccessToken), LogLevel.Info);
+            return true;
         }
     }
 }

--- a/twitch2tuner/TwitchApiManager.cs
+++ b/twitch2tuner/TwitchApiManager.cs
@@ -17,16 +17,18 @@ namespace twitch2tuner
         /// <summary>
         /// Invoke the Twitch API
         /// </summary>
-        public static Task<T> UseTwitchApi<T>(Func<TwitchAPI, Task<T>> action)
+        public static async Task<T> UseTwitchApi<T>(Func<TwitchAPI, Task<T>> action)
         {
             try
             {
-                return action(TwitchApi);
+                // Have to await here, instead of just returning the Task,
+                // otherwise we'll miss exceptions
+                return await action(TwitchApi);
             }
             catch (Exception ex)
             {
                 $"Encountered an error invoking the Twitch API: {ex}".Log(nameof(TwitchApiManager), LogLevel.Error);
-                return Task.FromResult(default(T));
+                return default;
             }
         }
     }

--- a/twitch2tuner/twitch2tuner.csproj
+++ b/twitch2tuner/twitch2tuner.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="EmbedIO" Version="3.4.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageReference Include="TwitchLib.Api" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Using the Twitch API [client credentials auth flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow), obtaining and maintaining the secrets necessary for authenticated API calls is much simpler.